### PR TITLE
Support back to elixir 1.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Gherkin.Mixfile do
     [
       app: :gherkin,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.1",
       source_url: "git@github.com:cabbage-ex/gherkin.git",
       homepage_url: "https://github.com/cabbage-ex/gherkin",
       build_embedded: Mix.env == :prod,


### PR DESCRIPTION
I've just imported this in to WhiteBread. I'm currently testing back to 1.1. As far as I can tell there's no reason why this Gherkin library can't support that far back (or even 1.0)