### PR TITLE
Allow Scenarios (or Examples) without description

### DIFF
--- a/lib/gherkin/parser/generic_line.ex
+++ b/lib/gherkin/parser/generic_line.ex
@@ -42,9 +42,9 @@ defmodule Gherkin.Parser.GenericLine do
     {feature, {:scenario_outline_example, []}}
   end
 
-  defp process("Scenario: " <> name, {feature, state}, line_number) do
+  defp process("Scenario:" <> name, {feature, state}, line_number) do
     tags = tags_from_state(state)
-    ScenarioParser.start_processing_scenario(feature, name, tags, line_number)
+    ScenarioParser.start_processing_scenario(feature, String.trim(name), tags, line_number)
   end
 
   defp process("Scenario Outline: " <> name, {feature, state}, line_number) do

--- a/lib/gherkin/parser/generic_line.ex
+++ b/lib/gherkin/parser/generic_line.ex
@@ -42,6 +42,10 @@ defmodule Gherkin.Parser.GenericLine do
     {feature, {:scenario_outline_example, []}}
   end
 
+  defp process("Example:" <> name, state, line_number) do
+    process("Scenario:" <> name, state, line_number)
+  end
+
   defp process("Scenario:" <> name, {feature, state}, line_number) do
     tags = tags_from_state(state)
     ScenarioParser.start_processing_scenario(feature, String.trim(name), tags, line_number)

--- a/test/gherkin/parser_test.exs
+++ b/test/gherkin/parser_test.exs
@@ -149,6 +149,19 @@ defmodule Gherkin.ParserTest do
       Given there are 1 coffees left in the machine
   """
 
+  @feature_text_with_scenario_and_example """
+    Feature: Serve coffee
+      Coffee should not be served until paid for
+      Coffee should not be served until the button has been pressed
+      If there is no coffee left then money should be refunded
+
+      Scenario: Buy last coffee
+        Given there are 1 coffees left in the machine
+
+      Example: Be sad that no coffee is left
+        Given there are 0 coffees left in the machine
+  """
+
   test "Parses the feature name" do
     assert %Feature{name: name, line: 1} = parse_feature(@feature_text)
     assert name == "Serve coffee"
@@ -170,6 +183,11 @@ defmodule Gherkin.ParserTest do
 
   test "reads in the correct number of scenarios" do
     assert %Feature{scenarios: scenarios, line: 1} = parse_feature(@feature_text)
+    assert Enum.count(scenarios) == 2
+  end
+
+  test "reads in scenarios introduces as examples" do
+    assert %Feature{scenarios: scenarios, line: 1} = parse_feature(@feature_text_with_scenario_and_example)
     assert Enum.count(scenarios) == 2
   end
 

--- a/test/gherkin/parser_test.exs
+++ b/test/gherkin/parser_test.exs
@@ -139,6 +139,16 @@ defmodule Gherkin.ParserTest do
     Given there are 1 coffees left in the machine
   """
 
+  @feature_with_scenario_with_no_name """
+  Feature: Serve coffee
+    Coffee should not be served until paid for
+    Coffee should not be served until the button has been pressed
+    If there is no coffee left then money should be refunded
+
+    Scenario:
+      Given there are 1 coffees left in the machine
+  """
+
   test "Parses the feature name" do
     assert %Feature{name: name, line: 1} = parse_feature(@feature_text)
     assert name == "Serve coffee"
@@ -161,6 +171,11 @@ defmodule Gherkin.ParserTest do
   test "reads in the correct number of scenarios" do
     assert %Feature{scenarios: scenarios, line: 1} = parse_feature(@feature_text)
     assert Enum.count(scenarios) == 2
+  end
+
+  test "Reads in scenarios with no name" do
+    assert %Feature{scenarios: scenarios, line: 1} = parse_feature(@feature_with_scenario_with_no_name)
+    assert Enum.count(scenarios) == 1
   end
 
   test "Gets the scenario's name" do


### PR DESCRIPTION
Scenarios without names were just getting silently skipped by the parser which was confusing me somewhat. 

Looking at the Gherkin reference (https://docs.cucumber.io/gherkin/reference/#example) it doesn't mention they are required to have names (as it does for Features, for instance). Also, scenarios without titles seem to work well in Cucumber, so I was hoping I'd be alright to make these titles optional? 

Whilst in that area, it says that Scenario is really a synonym for Example and either should work so I've added that in this PR too but I'm not bothered about that if you don't want it :)