### PR TITLE
Scenarios descriptions should not start with "When"

### DIFF
--- a/lib/gherkin/parsers/description_parser.ex
+++ b/lib/gherkin/parsers/description_parser.ex
@@ -18,6 +18,7 @@ defmodule Gherkin.Parsers.DescriptionParser do
     "Scenario",
     ~s{"""},
     "Given",
+    "When",
     "Then",
     "And",
     "But"

--- a/test/gherkin/parser_test.exs
+++ b/test/gherkin/parser_test.exs
@@ -41,6 +41,16 @@ defmodule Gherkin.ParserTest do
       Then I should be served a coffee
   """
 
+  @feature_with_scenario_description """
+  Feature: Have scenario descriptions
+
+    Scenario: I have a description and a step
+      This is the description
+
+      When this step is not part of the description
+      Then everything should be okay
+  """
+
   @feature_with_single_feature_tag """
   @beverage
   Feature: Serve coffee
@@ -239,6 +249,17 @@ defmodule Gherkin.ParserTest do
 
     %{scenarios: [%{steps: steps} | _]} = parse_feature(@feature_text)
     assert expected_steps == steps
+  end
+
+  test "Excludes steps from the scenario descriptions" do
+    %{scenarios: [%{description: description, steps: steps}]} =
+      parse_feature(@feature_with_scenario_description)
+
+    assert description == """
+           This is the description
+           """
+
+    assert Enum.count(steps) == 2
   end
 
   test "Parses the expected background steps" do


### PR DESCRIPTION
Scenario descriptions are not allowed to start their lines with a keyword, including `When`, but this is currently not accounted for. Compare:

```elixir
Gherkin.parse("""
Feature: feature
  Scenario: scenario
    Description
    Given step
""")
#=>
%Gherkin.Elements.Feature{
  background_steps: [],
  description: "",
  file: nil,
  line: 1,
  name: "feature",
  rules: [],
  scenarios: [
    %Gherkin.Elements.Scenario{
      description: "Description\n",
      line: 2,
      name: "scenario",
      steps: [
        %Gherkin.Elements.Step{
          doc_string: "",
          keyword: "Given",
          line: 4,
          table_data: [],
          text: "step"
        }
      ],
      tags: []
    }
  ],
  tags: []
}
```

to:

```elixir
Gherkin.parse("""
Feature: feature
  Scenario: scenario
    Description
    When step
    Then step
""")
#=>
%Gherkin.Elements.Feature{
  background_steps: [],
  description: "",
  file: nil,
  line: 1,
  name: "feature",
  rules: [],
  scenarios: [
    %Gherkin.Elements.Scenario{
      description: "Description\nWhen step\n",
      line: 2,
      name: "scenario",
      steps: [
        %Gherkin.Elements.Step{
          doc_string: "",
          keyword: "Then",
          line: 5,
          table_data: [],
          text: "step"
        }
      ],
      tags: []
    }
  ],
  tags: []
}
```

This patch fixes this issue.